### PR TITLE
Add cluster visualization components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # 1132-NCCU-Visualization
 Information Visualization
 
-cd backend/node server.js
-cd frontend/npm start
+## Development
+
+Start the backend server:
+
+```bash
+cd backend && node server.js
+```
+
+Start the React frontend:
+
+```bash
+cd frontend && npm start
+```
+
+Run tests:
+
+```bash
+npm test
+```
+
+Running `npm test` at the project root will execute the frontend test script.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import ProjectIntro from './components/ProjectIntro'; // 引入 ProjectIntro 組
 import SentimentChart from './components/SentimentChart'; // Import SentimentChart
 import FrequencyChart from './components/FrequencyChart'; // Import FrequencyChart
 import ClusteringScatterPlot from './components/ClusteringScatterPlot'; // Import ClusteringScatterPlot
+import ClusterDashboard from './components/ClusterDashboard';
 import ReadingPane from './components/ReadingPane'; // Import ReadingPane
 
 function App() {
@@ -83,7 +84,7 @@ function App() {
                                 {activeRightTab === 'sentiment' && <SentimentChart range={selectedRange} onTermSelect={handleTermSelect} />}
                                 {activeRightTab === 'term' && <FrequencyChart range={selectedRange} type="term" onTermSelect={(term, date) => handleTermSelect({ term, date })} />}
                                 {activeRightTab === 'ngram' && <FrequencyChart range={selectedRange} type="ngram" onTermSelect={(term, date) => handleTermSelect({ term, date })} />}
-                                {activeRightTab === 'clustering' && <ClusteringScatterPlot range={selectedRange} />}
+                                {activeRightTab === 'clustering' && <ClusterDashboard range={selectedRange} />}
                             </div>
                         </div>
 

--- a/frontend/src/components/ClusterBubbleChart.jsx
+++ b/frontend/src/components/ClusterBubbleChart.jsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as d3 from 'd3';
+import axios from 'axios';
+
+const sentimentColors = {
+    Positive: '#2ca02c',
+    Negative: '#d62728',
+    Neutral: '#1f77b4'
+};
+
+function ClusterBubbleChart({ range, onSelect }) {
+    const svgRef = useRef();
+    const [nodes, setNodes] = useState([]);
+
+    useEffect(() => {
+        if (!range || !range.from || !range.to) return;
+        const startDate = new Date(range.from).toISOString().split('T')[0];
+        const endDate = new Date(range.to).toISOString().split('T')[0];
+        axios.get('http://localhost:3001/api/clusters', { params: { startDate, endDate } })
+            .then(res => {
+                const grouped = d3.group(res.data, d => d.cluster_id);
+                const processed = Array.from(grouped, ([id, items]) => {
+                    const sentimentCount = d3.rollup(items, v => v.length, d => d.sentiment);
+                    let predominant = 'Neutral';
+                    let max = 0;
+                    for (const [s, c] of sentimentCount.entries()) {
+                        if (c > max) { max = c; predominant = s; }
+                    }
+                    return { id, count: items.length, sentiment: predominant };
+                });
+                setNodes(processed);
+            })
+            .catch(err => console.error('Cluster fetch error', err));
+    }, [range]);
+
+    useEffect(() => {
+        if (!svgRef.current) return;
+        const width = svgRef.current.clientWidth || 400;
+        const height = svgRef.current.clientHeight || 400;
+        const svg = d3.select(svgRef.current);
+        svg.selectAll('*').remove();
+
+        const simulation = d3.forceSimulation(nodes)
+            .force('charge', d3.forceManyBody().strength(5))
+            .force('center', d3.forceCenter(width / 2, height / 2))
+            .force('collision', d3.forceCollide().radius(d => Math.sqrt(d.count) * 2 + 20));
+
+        const node = svg.selectAll('circle')
+            .data(nodes)
+            .enter()
+            .append('circle')
+            .attr('r', d => Math.sqrt(d.count) * 2 + 20)
+            .attr('fill', d => sentimentColors[d.sentiment] || '#999')
+            .attr('stroke', '#fff')
+            .attr('stroke-width', 1.5)
+            .on('click', (event, d) => onSelect && onSelect(d.id));
+
+        const label = svg.selectAll('text')
+            .data(nodes)
+            .enter()
+            .append('text')
+            .text(d => d.id)
+            .attr('text-anchor', 'middle')
+            .attr('dy', '.35em')
+            .style('pointer-events', 'none')
+            .style('fill', '#fff');
+
+        simulation.on('tick', () => {
+            node.attr('cx', d => d.x)
+                .attr('cy', d => d.y);
+            label.attr('x', d => d.x)
+                .attr('y', d => d.y);
+        });
+
+        return () => simulation.stop();
+    }, [nodes, onSelect]);
+
+    return (
+        <svg ref={svgRef} style={{ width: '100%', height: '300px' }} />
+    );
+}
+
+export default ClusterBubbleChart;

--- a/frontend/src/components/ClusterDashboard.jsx
+++ b/frontend/src/components/ClusterDashboard.jsx
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+import ClusterBubbleChart from './ClusterBubbleChart';
+import ClusterTimeline from './ClusterTimeline';
+import ClusterHeatmap from './ClusterHeatmap';
+import ClusterWordCloud from './ClusterWordCloud';
+
+function ClusterDashboard({ range }) {
+    const [selected, setSelected] = useState(null);
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+            <ClusterBubbleChart range={range} onSelect={setSelected} />
+            <ClusterTimeline range={range} onBrush={() => {}} />
+            <ClusterHeatmap range={range} />
+            <ClusterWordCloud clusterId={selected} range={range} />
+        </div>
+    );
+}
+
+export default ClusterDashboard;

--- a/frontend/src/components/ClusterHeatmap.jsx
+++ b/frontend/src/components/ClusterHeatmap.jsx
@@ -52,20 +52,21 @@ function ClusterHeatmap({ range }) {
             .data(matrix)
             .enter()
             .append('g')
-            .attr('class','row')
-            .attr('transform', d => `translate(0,${clusters.indexOf(clusters[0])*gridHeight})`);
-
-        matrix.forEach((row, i) => {
-            clusters.forEach((c, j) => {
-                g.append('rect')
-                    .attr('x', j * gridWidth)
-                    .attr('y', i * gridHeight)
+            .attr('class', 'row')
+            .attr('transform', (d, i) => `translate(0,${i * gridHeight})`)
+            .each(function (row) {
+                d3.select(this)
+                    .selectAll('rect')
+                    .data(clusters)
+                    .enter()
+                    .append('rect')
+                    .attr('x', (c, j) => j * gridWidth)
                     .attr('width', gridWidth)
                     .attr('height', gridHeight)
-                    .attr('fill', color(row[c]));
-                g.append('title').text(row[c]);
+                    .attr('fill', c => color(row[c]))
+                    .append('title')
+                    .text(c => row[c]);
             });
-        });
 
         svg.append('g').attr('transform',`translate(60,${height-20})`)
             .call(d3.axisBottom(d3.scaleBand().domain(months).range([0, months.length*gridWidth])))

--- a/frontend/src/components/ClusterHeatmap.jsx
+++ b/frontend/src/components/ClusterHeatmap.jsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as d3 from 'd3';
+import axios from 'axios';
+
+function ClusterHeatmap({ range }) {
+    const svgRef = useRef();
+    const [matrix, setMatrix] = useState([]);
+    const [clusters, setClusters] = useState([]);
+    const [months, setMonths] = useState([]);
+
+    useEffect(() => {
+        if (!range || !range.from || !range.to) return;
+        const startDate = new Date(range.from).toISOString().split('T')[0];
+        const endDate = new Date(range.to).toISOString().split('T')[0];
+        axios.get('http://localhost:3001/api/clusters', { params: { startDate, endDate } })
+            .then(res => {
+                const formatMonth = d3.timeFormat('%Y-%m');
+                const monthsArr = Array.from(new Set(res.data.map(d => formatMonth(new Date(d.createdAt))))).sort();
+                const clustersArr = Array.from(new Set(res.data.map(d => d.cluster_id))).sort((a,b)=>a-b);
+                const matrixData = monthsArr.map(month => {
+                    const row = { month };
+                    clustersArr.forEach(c => { row[c] = 0; });
+                    return row;
+                });
+                const grouped = d3.rollups(res.data, v => v.length, d => formatMonth(new Date(d.createdAt)), d => d.cluster_id);
+                grouped.forEach(([m, arr]) => {
+                    const row = matrixData.find(d => d.month === m);
+                    arr.forEach(([c, count]) => { row[c] = count; });
+                });
+                setMatrix(matrixData);
+                setClusters(clustersArr);
+                setMonths(monthsArr);
+            })
+            .catch(err => console.error('Heatmap fetch error', err));
+    }, [range]);
+
+    useEffect(() => {
+        if (!svgRef.current || matrix.length === 0) return;
+        const width = svgRef.current.clientWidth || 400;
+        const height = 300;
+        const svg = d3.select(svgRef.current);
+        svg.selectAll('*').remove();
+
+        const gridWidth = (width - 80) / months.length;
+        const gridHeight = (height - 40) / clusters.length;
+        const color = d3.scaleSequential(d3.interpolateBlues)
+            .domain([0, d3.max(matrix, row => d3.max(clusters, c => row[c])) || 1]);
+
+        const g = svg.append('g').attr('transform','translate(60,20)');
+
+        g.selectAll('g.row')
+            .data(matrix)
+            .enter()
+            .append('g')
+            .attr('class','row')
+            .attr('transform', d => `translate(0,${clusters.indexOf(clusters[0])*gridHeight})`);
+
+        matrix.forEach((row, i) => {
+            clusters.forEach((c, j) => {
+                g.append('rect')
+                    .attr('x', j * gridWidth)
+                    .attr('y', i * gridHeight)
+                    .attr('width', gridWidth)
+                    .attr('height', gridHeight)
+                    .attr('fill', color(row[c]));
+                g.append('title').text(row[c]);
+            });
+        });
+
+        svg.append('g').attr('transform',`translate(60,${height-20})`)
+            .call(d3.axisBottom(d3.scaleBand().domain(months).range([0, months.length*gridWidth])))
+            .selectAll('text').attr('transform','rotate(-40)').attr('text-anchor','end');
+        svg.append('g').attr('transform','translate(60,20)')
+            .call(d3.axisLeft(d3.scaleBand().domain(clusters).range([0, clusters.length*gridHeight])));
+    }, [matrix, clusters, months]);
+
+    return <svg ref={svgRef} style={{ width: '100%', height: '300px' }} />;
+}
+
+export default ClusterHeatmap;

--- a/frontend/src/components/ClusterTimeline.jsx
+++ b/frontend/src/components/ClusterTimeline.jsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as d3 from 'd3';
+import axios from 'axios';
+
+function ClusterTimeline({ range, onBrush }) {
+    const svgRef = useRef();
+    const [stacked, setStacked] = useState([]);
+    const [keys, setKeys] = useState([]);
+
+    useEffect(() => {
+        if (!range || !range.from || !range.to) return;
+        const startDate = new Date(range.from).toISOString().split('T')[0];
+        const endDate = new Date(range.to).toISOString().split('T')[0];
+        axios.get('http://localhost:3001/api/clusters', { params: { startDate, endDate } })
+            .then(res => {
+                const formatMonth = d3.timeFormat('%Y-%m');
+                const grouped = d3.rollups(res.data,
+                    v => v.length,
+                    d => formatMonth(new Date(d.createdAt)),
+                    d => d.cluster_id);
+                const months = Array.from(new Set(res.data.map(d => formatMonth(new Date(d.createdAt))))).sort();
+                const clusters = Array.from(new Set(res.data.map(d => d.cluster_id))).sort((a,b)=>a-b);
+                const seriesData = months.map(month => {
+                    const entry = { month };
+                    clusters.forEach(c => entry[c] = 0);
+                    return entry;
+                });
+                grouped.forEach(([month, arr]) => {
+                    const obj = seriesData.find(d => d.month === month);
+                    arr.forEach(([cluster, count]) => { obj[cluster] = count; });
+                });
+                setStacked(seriesData);
+                setKeys(clusters);
+            })
+            .catch(err => console.error('Timeline fetch error', err));
+    }, [range]);
+
+    useEffect(() => {
+        if (!svgRef.current || stacked.length === 0) return;
+        const width = svgRef.current.clientWidth || 400;
+        const height = 300;
+        const svg = d3.select(svgRef.current);
+        svg.selectAll('*').remove();
+
+        const x = d3.scaleBand().domain(stacked.map(d => d.month)).range([40, width - 20]).padding(0.1);
+        const y = d3.scaleLinear().range([height - 30, 20]);
+        const stack = d3.stack().keys(keys);
+        const series = stack(stacked);
+        const maxY = d3.max(series, s => d3.max(s, d => d[1])) || 0;
+        y.domain([0, maxY]).nice();
+        const color = d3.scaleOrdinal(d3.schemeCategory10).domain(keys);
+
+        svg.append('g').attr('transform', `translate(0,${height - 30})`).call(d3.axisBottom(x).tickSizeOuter(0))
+            .selectAll('text').attr('transform', 'rotate(-40)').attr('text-anchor', 'end');
+        svg.append('g').attr('transform', 'translate(40,0)').call(d3.axisLeft(y));
+
+        const area = d3.area()
+            .x(d => x(d.data.month) + x.bandwidth()/2)
+            .y0(d => y(d[0]))
+            .y1(d => y(d[1]));
+
+        svg.selectAll('path.layer')
+            .data(series)
+            .enter()
+            .append('path')
+            .attr('class','layer')
+            .attr('fill', d => color(d.key))
+            .attr('d', area);
+
+        const brush = d3.brushX().extent([[40,20],[width-20,height-30]])
+            .on('end', e => {
+                if (!e.selection) return;
+                const [x0,x1] = e.selection;
+                const monthScale = d3.scaleQuantize().domain([40,width-20]).range(stacked.map(d=>d.month));
+                const start = monthScale(x0);
+                const end = monthScale(x1);
+                if (onBrush) onBrush({start,end});
+            });
+        svg.append('g').call(brush);
+    }, [stacked, keys, onBrush]);
+
+    return <svg ref={svgRef} style={{ width: '100%', height: '300px' }} />;
+}
+
+export default ClusterTimeline;

--- a/frontend/src/components/ClusterWordCloud.jsx
+++ b/frontend/src/components/ClusterWordCloud.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import * as d3 from 'd3';
+import axios from 'axios';
+
+function ClusterWordCloud({ clusterId, range, onTermClick }) {
+    const [words, setWords] = useState([]);
+
+    useEffect(() => {
+        if (clusterId === null || clusterId === undefined || !range) {
+            setWords([]);
+            return;
+        }
+        const startDate = new Date(range.from).toISOString().split('T')[0];
+        const endDate = new Date(range.to).toISOString().split('T')[0];
+        axios.get('http://localhost:3001/api/clusters', { params: { startDate, endDate } })
+            .then(res => {
+                const texts = res.data.filter(d => d.cluster_id === clusterId).map(d => d.cleaned_text.toLowerCase());
+                const freq = {};
+                texts.forEach(t => {
+                    t.split(/[^a-zA-Z0-9]+/).forEach(w => {
+                        if (w.length > 2) {
+                            freq[w] = (freq[w] || 0) + 1;
+                        }
+                    });
+                });
+                const items = Object.entries(freq).sort((a,b) => b[1]-a[1]).slice(0,40).map(([text,size])=>({text,size}));
+                setWords(items);
+            })
+            .catch(err => console.error('Wordcloud fetch error', err));
+    }, [clusterId, range]);
+
+    if (!words.length) return <div style={{height:'200px'}}>Select a cluster to see keywords</div>;
+
+    const max = d3.max(words, d => d.size) || 1;
+
+    return (
+        <div style={{ display: 'flex', flexWrap: 'wrap', width: '100%', height: '200px' }}>
+            {words.map((w,i) => (
+                <span key={i}
+                    onClick={() => onTermClick && onTermClick(w.text)}
+                    style={{
+                        fontSize: `${10 + (w.size / max) * 30}px`,
+                        marginRight: '8px',
+                        cursor: 'pointer'
+                    }}>
+                    {w.text}
+                </span>
+            ))}
+        </div>
+    );
+}
+
+export default ClusterWordCloud;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "1132-nccu-visualization-root",
+  "private": true,
+  "scripts": {
+    "test": "npm --prefix frontend test"
+  }
+}


### PR DESCRIPTION
## Summary
- add bubble chart to explore tweet clusters
- add stacked area timeline chart for clusters
- add heatmap of cluster activity
- add word cloud to inspect cluster keywords
- assemble new cluster dashboard and integrate into app

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d3bde7488328a55f40ac8ed81f81